### PR TITLE
fix: select subtitles matching original audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Select original-language auto-generated subtitles when dubbed audio also has auto-generated subtitle tracks.
+
 
 ## [2.24.6] - 2026-09-04
 ### Fixed

--- a/src/content/subtitles/subtitlesScript.js
+++ b/src/content/subtitles/subtitlesScript.js
@@ -20,11 +20,11 @@
  * 
  * YouTube provides different types of subtitle tracks:
  * - Manual tracks: Can be original language or translated
- * - ASR (Automatic Speech Recognition) tracks: Always in original video language
+ * - ASR (Automatic Speech Recognition) tracks: May also exist for dubbed audio
  * - Translated tracks: Generated from ASR track
  * 
  * Strategy to get original subtitles track:
- * 1. Find ASR track to determine original video language
+ * 1. Match ASR to the default/original audio language (or use a sole ASR track)
  * 2. Look for manual track in same language (matching base language code)
  * 3. Apply original language track if found
  */
@@ -119,11 +119,19 @@
 
             // If preference is "original", look for original language
             if (subtitlesLanguage === 'original') {
-                const asrTrack = captionTracks.find(track => track.kind === 'asr');
+                // Dubbed audio can have its own ASR tracks, so array order is not
+                // an indication of the original language. Audio IDs use lang.variant.
+                const originalAudio = response.streamingData?.adaptiveFormats
+                    ?.find(format => format.audioTrack?.audioIsDefault)?.audioTrack;
+                const originalLanguage = originalAudio?.id?.split('.')[0];
+                const asrTracks = captionTracks.filter(track => track.kind === 'asr');
+                const asrTrack = originalLanguage
+                    ? asrTracks.find(track => languageCodesMatch(track.languageCode, originalLanguage))
+                    : (asrTracks.length === 1 ? asrTracks[0] : undefined);
 
                 if (!asrTrack) {
                     // Fallback: if there's only one subtitle track, assume it's the original
-                    if (captionTracks.length === 1) {
+                    if (captionTracks.length === 1 && !captionTracks[0].kind) {
                         const singleTrack = captionTracks[0];
                         // Skip if already on this track
                         if (currentTrack && languageCodesMatch(currentTrack.languageCode, singleTrack.languageCode) && !currentTrack.kind && !currentTrack.translationLanguage) {

--- a/tests/subtitles.test.mts
+++ b/tests/subtitles.test.mts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025-present YouGo (https://github.com/youg-o)
+ * This program is licensed under the GNU Affero General Public License v3.0.
+ * You may redistribute it and/or modify it under the terms of the license.
+ *
+ * Attribution must be given to the original author.
+ * This program is distributed without any warranty; see the license for details.
+*/
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { test } from 'node:test';
+
+const source = readFileSync(new URL('../src/content/subtitles/subtitlesScript.js', import.meta.url), 'utf8');
+type Track = { languageCode?: string; kind?: string; name?: { simpleText: string } };
+
+const asr = (languageCode: string): Track => ({ languageCode, kind: 'asr', name: { simpleText: languageCode } });
+const manual = (languageCode: string): Track => ({ languageCode, name: { simpleText: languageCode } });
+
+function select(captionTracks: Track[], { audioLanguage = 'en-US', enabled = true, current = {} }: { audioLanguage?: string | null; enabled?: boolean; current?: Track } = {}) {
+    let selected = current;
+    const player = {
+        getOption: () => current,
+        getPlayerResponse: () => ({
+            captions: { playerCaptionsTracklistRenderer: { captionTracks } },
+            streamingData: audioLanguage ? { adaptiveFormats: [
+                { audioTrack: { id: 'ar.10', audioIsDefault: false, isAutoDubbed: true } },
+                { audioTrack: { id: `${audioLanguage}.4`, audioIsDefault: true } }
+            ] } : undefined
+        }),
+        setOption: (_module: string, _option: string, track: Track) => { selected = track; }
+    };
+    runInNewContext(source, {
+        document: { getElementById: () => player },
+        window: { location: { pathname: '/watch' } },
+        localStorage: { getItem: (key: string) => ({
+            'ynt-subtitlesLanguage': 'original',
+            'ynt-subtitlesAsrEnabled': String(enabled)
+        } as Record<string, string>)[key] },
+        setTimeout: () => assert.fail('Unexpected retry'),
+        console
+    });
+    return selected;
+}
+
+// Minimized from 3QtoaoMYzMU: Arabic precedes English; original audio is en-US.4.
+test('original captions select English ASR, not the first dubbed ASR', () => {
+    assert.equal(select([asr('ar'), asr('en')]).languageCode, 'en');
+});
+
+test('selection does not depend on caption order', () => {
+    assert.equal(select([asr('en'), asr('ar')]).languageCode, 'en');
+});
+test('corrects an already active Arabic ASR track', () => {
+    assert.equal(select([asr('ar'), asr('en')], { current: asr('ar') }).languageCode, 'en');
+});
+test('prefers manual captions matching the original base language', () => {
+    const track = manual('en-GB');
+    assert.equal(select([asr('ar'), asr('en'), track]), track);
+});
+test('keeps ASR disabled when requested', () => {
+    assert.equal(select([asr('ar'), asr('en')], { enabled: false }).languageCode, undefined);
+});
+test('supports legacy single ASR without audio metadata', () => {
+    assert.equal(select([asr('fr')], { audioLanguage: null }).languageCode, 'fr');
+});
+test('does not guess from multiple ASR tracks without audio metadata', () => {
+    assert.equal(select([asr('ar'), asr('en')], { audioLanguage: null }).languageCode, undefined);
+});
+test('preserves the single manual track fallback', () => {
+    const track = manual('fr');
+    assert.equal(select([track], { audioLanguage: null }), track);
+});
+test('does not treat a lone dubbed ASR as a manual fallback', () => {
+    assert.equal(select([asr('ar')]).languageCode, undefined);
+});
+test('uses the original language rather than hardcoding English', () => {
+    assert.equal(select([asr('ar'), asr('en'), asr('fr')], { audioLanguage: 'fr-FR' }).languageCode, 'fr');
+});


### PR DESCRIPTION
Fixes #192

YouTube now provides ASR captions for dubbed audio as well as the original audio. Selecting the first ASR track incorrectly identifies Arabic as the original language and can also overlook manual English captions.

Match ASR captions to the default/original audio language, preserving the preference for manual captions. When audio metadata is unavailable, fall back only to a single unambiguous ASR track.

Validations done:
- Added regression tests passes: `node --test tests/subtitles.test.mts`.
- Chromium build and TypeScript checks pass.
- Verified the loaded extension selects English ASR on `3QtoaoMYzMU` and manual English captions on `Cm00TFrmQRs`.
- Verified German manual captions works as expected on `p8iwsg64rjs`.

GPT-6 Astra has helped in developing this patch.

I realized there weren't any regression tests before. So if it is not needed I would be happy to remove the new 80-line test file.

Pls kindly review. :)